### PR TITLE
update today's background color to match choco theme

### DIFF
--- a/src/UIComponents/Calendar/Calendar.jsx
+++ b/src/UIComponents/Calendar/Calendar.jsx
@@ -67,7 +67,7 @@ const Calendar = () => {
         key={day}
         className={
           "p-2 text-center cursor-pointer rounded-full transition-all " +
-          (isToday ? "bg-blue-500 text-white " : "") +
+          (isToday ? "bg-[#603F26] text-white " : "") +
           (isSelected ? "bg-green-500 text-white " : "") +
           "hover:bg-gray-200 hover:text-black"
         }


### PR DESCRIPTION
Changed the background color for the current day in the calendar from default to `#603F26` with white text to better align with the chocolate-themed UI.